### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/k22036/random-cat/security/code-scanning/2](https://github.com/k22036/random-cat/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal rights the workflow needs. For a pure CI job that only checks out code and runs local commands, `contents: read` is typically sufficient. This block can be defined at the top level of the workflow (applies to all jobs) or at the job level for finer control.

For this workflow, the best fix without changing existing functionality is to add a top-level `permissions:` block after the `on:` section and before `jobs:`. The job only checks out the repository and runs Bun commands; it does not push changes, open issues, or modify pull requests, so `contents: read` is enough. No new imports, actions, or additional configuration are needed. Specifically, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `workflow_dispatch:` line (or its following blank line) and the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * CI/CDワークフローの内部設定を更新しました。

このリリースにはユーザー向けの変更は含まれていません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->