### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/k22036/random-cat/security/code-scanning/1](https://github.com/k22036/random-cat/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. Since this job only checks out code, installs dependencies, runs tests, and uploads artifacts, it only needs read access to repository contents; no other scoped write permissions are required.

The best minimal fix is to add a `permissions:` block at the workflow root (top level, alongside `on:` and `jobs:`) setting `contents: read`. This will apply to all jobs in this workflow (currently just `test`) unless a job overrides it. Concretely, edit `.github/workflows/playwright-test.yml` to insert:

```yaml
permissions:
  contents: read
```

after the `on:` block and before `jobs:`. No additional methods, imports, or definitions are needed, and this change does not alter the existing behavior of the steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフロー設定を更新しました。

---

**注記:** このリリースには、エンドユーザーに直接影響する変更は含まれていません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->